### PR TITLE
DR2-1093 Preservica Config Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ All of these files are run at once when terraform runs.
 `download_metadata_and_files_lambda.tf` Resources for the disaster recovery lambda.
 `disaster_recovery` Shared resources for the disaster recovery workflow.
 `slack_notifications_lambda` Resources for the notifications lambda.
+`deploy_preservica_config` A lambda, queue, topic and bucket for deploying XML config to Preservica.
 
 
 ## Deployment

--- a/common.tf
+++ b/common.tf
@@ -93,7 +93,7 @@ module "dr2_developer_key" {
   default_policy_variables = {
     user_roles    = [data.aws_ssm_parameter.dev_admin_role.value, module.preservica_config_lambda.lambda_role_arn]
     ci_roles      = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
-    service_names = ["s3", "sns"]
+    service_names = ["s3", "sns", "logs"]
   }
 }
 

--- a/common.tf
+++ b/common.tf
@@ -91,8 +91,9 @@ module "dr2_developer_key" {
   source   = "git::https://github.com/nationalarchives/da-terraform-modules//kms"
   key_name = "${local.environment}-kms-dr2-dev"
   default_policy_variables = {
-    user_roles = [data.aws_ssm_parameter.dev_admin_role.value, module.preservica_config_lambda.lambda_role_arn]
-    ci_roles   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
+    user_roles    = [data.aws_ssm_parameter.dev_admin_role.value, module.preservica_config_lambda.lambda_role_arn]
+    ci_roles      = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
+    service_names = ["s3", "sns"]
   }
 }
 

--- a/common.tf
+++ b/common.tf
@@ -75,3 +75,27 @@ module "outbound_https_access_only" {
     protocol    = "tcp"
   }]
 }
+
+module "dr2_kms_key" {
+  source   = "git::https://github.com/nationalarchives/da-terraform-modules//kms"
+  key_name = "${local.environment}-kms-dr2"
+  default_policy_variables = {
+    user_roles = [
+      module.download_metadata_and_files_lambda.lambda_role_arn
+    ]
+    ci_roles = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
+  }
+}
+
+module "dr2_developer_key" {
+  source   = "git::https://github.com/nationalarchives/da-terraform-modules//kms"
+  key_name = "${local.environment}-kms-dr2-dev"
+  default_policy_variables = {
+    user_roles = [data.aws_ssm_parameter.dev_admin_role.value, module.preservica_config_lambda.lambda_role_arn]
+    ci_roles   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
+  }
+}
+
+data "aws_ssm_parameter" "dev_admin_role" {
+  name = "/${local.environment}/developer_role"
+}

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -30,6 +30,9 @@ module "preservica_config_sns" {
   }
   topic_name  = "${local.environment}-preservica-config"
   kms_key_arn = module.dr2_developer_key.kms_key_arn
+  sqs_subscriptions = {
+    preservica_config_queue = module.preservica_config_queue.sqs_arn
+  }
 }
 
 module "preservica_config_queue" {

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -38,8 +38,10 @@ module "preservica_config_sns" {
 module "preservica_config_queue" {
   source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
   queue_name = "${local.environment}-preservica-config"
-  sqs_policy = templatefile("${path.module}/templates/sqs/sqs_access_policy.json.tpl", {
+  sqs_policy = templatefile("${path.module}/templates/sqs/sns_send_message_policy.json.tpl", {
     account_id = data.aws_caller_identity.current.account_id, queue_name = "${local.environment}-preservica-config"
+    queue_name = "${local.environment}-preservica-config"
+    topic_arn  = module.preservica_config_sns.sns_arn
   })
   kms_key_id = module.dr2_developer_key.kms_key_arn
 }

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -43,7 +43,8 @@ module "preservica_config_queue" {
     queue_name = "${local.environment}-preservica-config"
     topic_arn  = module.preservica_config_sns.sns_arn
   })
-  kms_key_id = module.dr2_developer_key.kms_key_arn
+  kms_key_id         = module.dr2_developer_key.kms_key_arn
+  visibility_timeout = 60
 }
 
 module "preservica_config_lambda" {
@@ -53,7 +54,8 @@ module "preservica_config_lambda" {
   lambda_sqs_queue_mappings = {
     preservica_config_queue = module.preservica_config_queue.sqs_arn
   }
-  timeout_seconds = 60
+  timeout_seconds       = 60
+  log_group_kms_key_arn = module.dr2_developer_key.kms_key_arn
   policies = {
     "${local.preservica_config_lambda_name}-policy" = templatefile("./templates/iam_policy/preservica_config_policy.json.tpl", {
       secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -44,7 +44,7 @@ module "preservica_config_queue" {
     topic_arn  = module.preservica_config_sns.sns_arn
   })
   kms_key_id         = module.dr2_developer_key.kms_key_arn
-  visibility_timeout = 60
+  visibility_timeout = 360
 }
 
 module "preservica_config_lambda" {
@@ -72,8 +72,8 @@ module "preservica_config_lambda" {
     security_group_ids = [module.outbound_https_access_only.security_group_id]
   }
   plaintext_env_vars = {
-    SECRET_NAME    = aws_secretsmanager_secret.preservica_secret.name
-    PRESERVICA_URL = data.aws_ssm_parameter.preservica_url.value
+    PRESERVICA_SECRET_NAME = aws_secretsmanager_secret.preservica_secret.name
+    PRESERVICA_API_URL     = data.aws_ssm_parameter.preservica_url.value
   }
   tags = {
     Name      = local.preservica_config_lambda_name

--- a/deploy_preservica_config.tf
+++ b/deploy_preservica_config.tf
@@ -1,0 +1,75 @@
+locals {
+  preservica_config_bucket_name = "${local.environment}-dr2-preservica-config"
+  preservica_config_lambda_name = "${local.environment}-preservica-config"
+}
+module "preservica_config_bucket" {
+  source      = "git::https://github.com/nationalarchives/da-terraform-modules//s3"
+  bucket_name = local.preservica_config_bucket_name
+  sns_topic_config = {
+    "s3:ObjectCreated:*" = module.preservica_config_sns.sns_arn
+  }
+  kms_key_arn = module.dr2_developer_key.kms_key_arn
+  bucket_policy = templatefile("${path.module}/templates/s3/preservica_config_bucket_policy.json.tpl", {
+    preservica_config_lambda_role_arn = module.preservica_config_lambda.lambda_role_arn
+    bucket_name                       = local.preservica_config_bucket_name
+  })
+  logging_bucket_policy = templatefile("${path.module}/templates/s3/log_bucket_policy.json.tpl", {
+    bucket_name = "${local.preservica_config_bucket_name}-logs", account_id = var.dp_account_number
+  })
+}
+
+module "preservica_config_sns" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//sns"
+  sns_policy = templatefile("${path.module}/templates/sns/s3_notifications_policy.json.tpl", {
+    topic_name  = "${local.environment}-preservica-config"
+    bucket_name = "${local.environment}-dr2-preservica-config"
+    account_id  = data.aws_caller_identity.current.account_id
+  })
+  tags = {
+    Name = "Preservica Config SNS"
+  }
+  topic_name  = "${local.environment}-preservica-config"
+  kms_key_arn = module.dr2_developer_key.kms_key_arn
+}
+
+module "preservica_config_queue" {
+  source     = "git::https://github.com/nationalarchives/da-terraform-modules//sqs"
+  queue_name = "${local.environment}-preservica-config"
+  sqs_policy = templatefile("${path.module}/templates/sqs/sqs_access_policy.json.tpl", {
+    account_id = data.aws_caller_identity.current.account_id, queue_name = "${local.environment}-preservica-config"
+  })
+  kms_key_id = module.dr2_developer_key.kms_key_arn
+}
+
+module "preservica_config_lambda" {
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"
+  function_name = local.preservica_config_lambda_name
+  handler       = "uk.gov.nationalarchives.dp.Lambda::handleRequest"
+  lambda_sqs_queue_mappings = {
+    preservica_config_queue = module.preservica_config_queue.sqs_arn
+  }
+  timeout_seconds = 60
+  policies = {
+    "${local.preservica_config_lambda_name}-policy" = templatefile("./templates/iam_policy/preservica_config_policy.json.tpl", {
+      secrets_manager_secret_arn = aws_secretsmanager_secret.preservica_secret.arn
+      preservica_config_queue    = module.preservica_config_queue.sqs_arn
+      bucket_name                = local.preservica_config_bucket_name
+      account_id                 = var.dp_account_number
+      lambda_name                = local.preservica_config_lambda_name
+    })
+  }
+  memory_size = 512
+  runtime     = "java17"
+  vpc_config = {
+    subnet_ids         = module.vpc.private_subnets
+    security_group_ids = [module.outbound_https_access_only.security_group_id]
+  }
+  plaintext_env_vars = {
+    SECRET_NAME    = aws_secretsmanager_secret.preservica_secret.name
+    PRESERVICA_URL = data.aws_ssm_parameter.preservica_url.value
+  }
+  tags = {
+    Name      = local.preservica_config_lambda_name
+    CreatedBy = "dp-terraform-environments"
+  }
+}

--- a/disaster_recovery.tf
+++ b/disaster_recovery.tf
@@ -11,4 +11,5 @@ module "disaster_recovery_bucket" {
     download_files_metadata_lambda_role_arn = module.download_metadata_and_files_lambda.lambda_role_arn,
     bucket_name                             = local.disaster_recovery_bucket_name
   })
+  kms_key_arn = module.dr2_kms_key.kms_key_arn
 }

--- a/download_metadata_and_files_lambda.tf
+++ b/download_metadata_and_files_lambda.tf
@@ -49,5 +49,6 @@ module "download_files_sqs" {
   tags = {
     CreatedBy = "dp-terraform-environments"
   }
+  kms_key_id = module.dr2_kms_key.kms_key_arn
 }
 

--- a/templates/iam_policy/preservica_config_policy.json.tpl
+++ b/templates/iam_policy/preservica_config_policy.json.tpl
@@ -1,0 +1,43 @@
+{
+  "Statement": [
+    {
+      "Action": "secretsmanager:GetSecretValue",
+      "Effect": "Allow",
+      "Resource": "${secrets_manager_secret_arn}",
+      "Sid": "readSecretsManager"
+    },
+    {
+      "Action": [
+        "sqs:ReceiveMessage",
+        "sqs:GetQueueAttributes",
+        "sqs:DeleteMessage"
+      ],
+      "Effect": "Allow",
+      "Resource": "${preservica_config_queue}",
+      "Sid": "readSqs"
+    },
+    {
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    },
+    {
+      "Action": [
+        "logs:PutLogEvents",
+        "logs:CreateLogStream",
+        "logs:CreateLogGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/${lambda_name}:*:*",
+        "arn:aws:logs:eu-west-2:${account_id}:log-group:/aws/lambda/${lambda_name}:*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}

--- a/templates/s3/preservica_config_bucket_policy.json.tpl
+++ b/templates/s3/preservica_config_bucket_policy.json.tpl
@@ -1,0 +1,30 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "${preservica_config_lambda_role_arn}"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": "arn:aws:s3:::${bucket_name}/*"
+    },
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "s3:*",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      }
+    }
+  ]
+}

--- a/templates/sns/s3_notifications_policy.json.tpl
+++ b/templates/sns/s3_notifications_policy.json.tpl
@@ -1,0 +1,23 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Action": [
+        "SNS:Publish"
+      ],
+      "Resource": "arn:aws:sns:eu-west-2:${account_id}:${topic_name}",
+      "Condition": {
+        "ArnLike": {
+          "aws:SourceArn": "arn:aws:s3:*:*:${bucket_name}"
+        },
+        "StringEquals": {
+          "aws:SourceAccount": "${account_id}"
+        }
+      }
+    }
+  ]
+}

--- a/templates/sqs/sns_send_message_policy.json.tpl
+++ b/templates/sqs/sns_send_message_policy.json.tpl
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "sns.amazonaws.com"
+      },
+      "Action": "sqs:SendMessage",
+      "Resource": "arn:aws:sqs:eu-west-2:${account_id}:${queue_name}",
+      "Condition": {
+        "ArnEquals": {
+          "aws:SourceArn": "${topic_arn}"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Add Preservica config lambda.
    
I've used this PR to update the existing S3 buckets and SQS queues to use KMS.
There are two keys. dr2_kms_key only has the download_metadata_files lambda role allowed to encrypt and decrypt.
dr2_developer allows the developer admin roles to encrypt and decrypt.
This will be used for config buckets and queues like preservica config and the deploy bucket.

The tests won't pass on this until https://github.com/nationalarchives/da-terraform-modules/pull/9 is merged but this is ready for review.
