### PR TITLE
DR2-1092 Add region to logs service name.

### DIFF
--- a/common.tf
+++ b/common.tf
@@ -95,7 +95,7 @@ module "dr2_developer_key" {
   default_policy_variables = {
     user_roles    = [data.aws_ssm_parameter.dev_admin_role.value, module.preservica_config_lambda.lambda_role_arn]
     ci_roles      = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/IntgTerraformRole"]
-    service_names = ["s3", "sns", "logs"]
+    service_names = ["s3", "sns", "logs.eu-west-2"]
   }
 }
 


### PR DESCRIPTION
As per https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html
The region name is needed. You get an error creating encrypted log
groups if it's omitted.

Needs https://github.com/nationalarchives/da-terraform-modules/pull/14
before this can be deployed.
