### PR TITLE
DR2-1123 Add event generation lambda to the policy.

### DIFF
--- a/deploy_roles.tf
+++ b/deploy_roles.tf
@@ -12,8 +12,9 @@ module "deploy_lambda_policy" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy"
   name   = "${local.environment_title}DPGithubActionsDeployLambdaPolicy"
   policy_string = templatefile("${path.module}/templates/iam_policy/deploy_lambda_policy.json.tpl", {
-    download_metadata_lambda_arn  = module.download_metadata_and_files_lambda.lambda_arn,
-    slack_notification_lambda_arn = module.slack_notifications_lambda.lambda_arn
-    bucket_name                   = "mgmt-dp-code-deploy"
+    download_metadata_lambda_arn       = module.download_metadata_and_files_lambda.lambda_arn,
+    slack_notification_lambda_arn      = module.slack_notifications_lambda.lambda_arn
+    entity_event_generation_lambda_arn = module.entity_event_generator_lambda.lambda_arn
+    bucket_name                        = "mgmt-dp-code-deploy"
   })
 }

--- a/templates/iam_policy/deploy_lambda_policy.json.tpl
+++ b/templates/iam_policy/deploy_lambda_policy.json.tpl
@@ -12,6 +12,7 @@
       "Resource": [
         "${download_metadata_lambda_arn}",
         "${slack_notification_lambda_arn}",
+        "${entity_event_generation_lambda_arn}",
         "arn:aws:s3:::${bucket_name}/*"
       ]
     }


### PR DESCRIPTION
This is the policy GitHub actions uses to deploy to lambda. We may add a
wildcard if this gets annoying but for now we can add them in one at a
time.
